### PR TITLE
feat: My Targets, Projects dashboard tabs and Work Management search/…

### DIFF
--- a/app/src/main/java/com/atvantiq/wfms/data/repository/budget/BudgetRepo.kt
+++ b/app/src/main/java/com/atvantiq/wfms/data/repository/budget/BudgetRepo.kt
@@ -1,0 +1,22 @@
+package com.atvantiq.wfms.data.repository.budget
+
+import com.atvantiq.wfms.data.prefs.PrefKeys
+import com.atvantiq.wfms.data.prefs.SecurePrefMain
+import com.atvantiq.wfms.models.targets.MyProjectsResponse
+import com.atvantiq.wfms.models.targets.MyTargetsResponse
+import com.atvantiq.wfms.network.ApiService
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BudgetRepo @Inject constructor(
+    private val apiService: ApiService,
+    private val prefMain: SecurePrefMain
+) : IBudgetRepo {
+
+    override suspend fun myTargets(month: String?): MyTargetsResponse =
+        apiService.myTargets("Bearer " + prefMain.get(PrefKeys.LOGIN_TOKEN, ""), month)
+
+    override suspend fun myProjects(month: String?): MyProjectsResponse =
+        apiService.myProjects("Bearer " + prefMain.get(PrefKeys.LOGIN_TOKEN, ""), month)
+}

--- a/app/src/main/java/com/atvantiq/wfms/data/repository/budget/IBudgetRepo.kt
+++ b/app/src/main/java/com/atvantiq/wfms/data/repository/budget/IBudgetRepo.kt
@@ -1,0 +1,11 @@
+package com.atvantiq.wfms.data.repository.budget
+
+import com.atvantiq.wfms.models.targets.MyProjectsResponse
+import com.atvantiq.wfms.models.targets.MyTargetsResponse
+
+interface IBudgetRepo {
+
+    suspend fun myTargets(month: String?): MyTargetsResponse
+
+    suspend fun myProjects(month: String?): MyProjectsResponse
+}

--- a/app/src/main/java/com/atvantiq/wfms/models/targets/MyProjectsResponse.kt
+++ b/app/src/main/java/com/atvantiq/wfms/models/targets/MyProjectsResponse.kt
@@ -1,0 +1,41 @@
+package com.atvantiq.wfms.models.targets
+
+import com.google.gson.annotations.SerializedName
+
+data class MyProjectsResponse(
+    @SerializedName("code") val code: Int,
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("message") val message: String,
+    @SerializedName("data") val data: MyProjectsData?
+)
+
+data class MyProjectsData(
+    @SerializedName("month") val month: String?,
+    @SerializedName("total_count") val totalCount: Int?,
+    @SerializedName("items") val items: List<ProjectBudgetItem>?
+)
+
+data class ProjectBudgetItem(
+    @SerializedName("project") val project: ProjectInfo?,
+    @SerializedName("client") val client: ClientInfo?,
+    @SerializedName("circle") val circle: CircleInfo?,
+    @SerializedName("status") val status: String?,
+    @SerializedName("sites") val sites: TargetSites?,
+    @SerializedName("revenue") val revenue: TargetRevenue?
+)
+
+data class ProjectInfo(
+    @SerializedName("id") val id: Long?,
+    @SerializedName("name") val name: String?
+)
+
+data class ClientInfo(
+    @SerializedName("id") val id: Long?,
+    @SerializedName("name") val name: String?
+)
+
+data class CircleInfo(
+    @SerializedName("id") val id: Long?,
+    @SerializedName("code") val code: String?,
+    @SerializedName("name") val name: String?
+)

--- a/app/src/main/java/com/atvantiq/wfms/models/targets/MyTargetsResponse.kt
+++ b/app/src/main/java/com/atvantiq/wfms/models/targets/MyTargetsResponse.kt
@@ -1,0 +1,54 @@
+package com.atvantiq.wfms.models.targets
+
+import com.google.gson.annotations.SerializedName
+
+data class MyTargetsResponse(
+    @SerializedName("code") val code: Int,
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("message") val message: String,
+    @SerializedName("data") val data: MyTargetsData?
+)
+
+data class MyTargetsData(
+    @SerializedName("employee") val employee: TargetEmployee?,
+    @SerializedName("month") val month: String?,
+    @SerializedName("status") val status: String?,
+    @SerializedName("revenue") val revenue: TargetRevenue?,
+    @SerializedName("sites") val sites: TargetSites?,
+    @SerializedName("active_days") val activeDays: TargetActiveDays?,
+    @SerializedName("hours_worked") val hoursWorked: TargetHoursWorked?,
+    @SerializedName("efficiency") val efficiency: String?
+)
+
+data class TargetEmployee(
+    @SerializedName("id") val id: Long?,
+    @SerializedName("name") val name: String?,
+    @SerializedName("designation") val designation: String?,
+    @SerializedName("reporting_manager") val reportingManager: String?
+)
+
+data class TargetRevenue(
+    @SerializedName("target") val target: Double?,
+    @SerializedName("achieved") val achieved: Double?,
+    @SerializedName("variation") val variation: Double?,
+    @SerializedName("achievement_percentage") val achievementPercentage: String?
+)
+
+data class TargetSites(
+    @SerializedName("target") val target: Int?,
+    @SerializedName("achieved") val achieved: Int?,
+    @SerializedName("variation") val variation: Int?,
+    @SerializedName("achievement_percentage") val achievementPercentage: String?
+)
+
+data class TargetActiveDays(
+    @SerializedName("target") val target: Int?,
+    @SerializedName("achieved") val achieved: Int?,
+    @SerializedName("achievement_percentage") val achievementPercentage: String?
+)
+
+data class TargetHoursWorked(
+    @SerializedName("target") val target: Double?,
+    @SerializedName("achieved") val achieved: Double?,
+    @SerializedName("achievement_percentage") val achievementPercentage: String?
+)

--- a/app/src/main/java/com/atvantiq/wfms/ui/screens/adapters/ProjectBudgetAdapter.kt
+++ b/app/src/main/java/com/atvantiq/wfms/ui/screens/adapters/ProjectBudgetAdapter.kt
@@ -1,0 +1,107 @@
+package com.atvantiq.wfms.ui.screens.adapters
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.atvantiq.wfms.R
+import com.atvantiq.wfms.databinding.ItemProjectBudgetBinding
+import com.atvantiq.wfms.models.targets.ProjectBudgetItem
+
+class ProjectBudgetAdapter : RecyclerView.Adapter<ProjectBudgetAdapter.ViewHolder>() {
+
+    private val items = mutableListOf<ProjectBudgetItem>()
+
+    fun submitList(data: List<ProjectBudgetItem>) {
+        items.clear()
+        items.addAll(data)
+        notifyDataSetChanged()
+    }
+
+    inner class ViewHolder(val binding: ItemProjectBudgetBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding: ItemProjectBudgetBinding = DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_project_budget,
+            parent,
+            false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        val ctx = holder.itemView.context
+        val res = ctx.resources
+
+        holder.binding.tvProjectName.text = item.project?.name ?: "-"
+
+        // "Client · Circle"
+        val clientPart = item.client?.name.orEmpty()
+        val circlePart = item.circle?.name.orEmpty()
+        holder.binding.tvClientLocation.text = when {
+            clientPart.isNotBlank() && circlePart.isNotBlank() -> "$clientPart · $circlePart"
+            clientPart.isNotBlank() -> clientPart
+            circlePart.isNotBlank() -> circlePart
+            else -> "-"
+        }
+
+        // Progress from revenue achievement_percentage string e.g. "0.0%"
+        val revPct = stripPct(item.revenue?.achievementPercentage).toInt().coerceIn(0, 100)
+        holder.binding.progressProject.progress = revPct
+
+        // Sites: "achieved / target"
+        val sitesAchieved = item.sites?.achieved ?: 0
+        val sitesTarget = item.sites?.target ?: 0
+        holder.binding.tvSitesRatio.text = "$sitesAchieved/$sitesTarget"
+
+        // Revenue: "$0 of $108K"
+        val revAchieved = item.revenue?.achieved ?: 0.0
+        val revTarget = item.revenue?.target ?: 0.0
+        holder.binding.tvRevenue.text = "${formatCurrency(revAchieved)} of ${formatCurrency(revTarget)}"
+
+        // Status badge
+        val status = item.status?.lowercase() ?: ""
+        val (bgRes, textColorRes, label) = when {
+            status == "on_track" -> Triple(
+                R.drawable.bg_status_on_track,
+                R.color.status_present_text,
+                ctx.getString(R.string.on_track)
+            )
+            status == "above_target" -> Triple(
+                R.drawable.bg_status_on_track,
+                R.color.status_present_text,
+                ctx.getString(R.string.status_above_target)
+            )
+            else -> Triple(
+                R.drawable.bg_status_under_target,
+                R.color.status_holiday_text,
+                ctx.getString(R.string.status_under_target)
+            )
+        }
+        holder.binding.tvStatus.apply {
+            text = label
+            setBackgroundResource(bgRes)
+            setTextColor(res.getColor(textColorRes, ctx.theme))
+        }
+
+        holder.binding.executePendingBindings()
+    }
+
+    override fun getItemCount() = items.size
+
+    private fun stripPct(value: String?): Double =
+        value?.trimEnd('%')?.toDoubleOrNull() ?: 0.0
+
+    private fun formatCurrency(amount: Double): String {
+        val abs = Math.abs(amount)
+        val sign = if (amount < 0) "-" else ""
+        return when {
+            abs >= 1_000_000 -> "${sign}$${String.format("%.1f", abs / 1_000_000)}M"
+            abs >= 1_000 -> "${sign}$${String.format("%.0f", abs / 1_000)}K"
+            else -> "${sign}$${String.format("%.0f", abs)}"
+        }
+    }
+}

--- a/app/src/main/java/com/atvantiq/wfms/ui/screens/attendance/WorkFilter.kt
+++ b/app/src/main/java/com/atvantiq/wfms/ui/screens/attendance/WorkFilter.kt
@@ -1,0 +1,10 @@
+package com.atvantiq.wfms.ui.screens.attendance
+
+import com.atvantiq.wfms.constants.StatusCodes
+
+enum class WorkFilter(val label: String, val statusParam: String?) {
+    ALL("All", null),
+    PENDING("Pending", "${StatusCodes.OPEN},${StatusCodes.ACCEPTED}"),
+    ACTIVE("Active", "${StatusCodes.WIP}"),
+    COMPLETED("Completed", "${StatusCodes.COMPLETED}")
+}

--- a/app/src/main/java/com/atvantiq/wfms/ui/screens/dashboard/tabs/projectDashboard/ProjectDashboardVM.kt
+++ b/app/src/main/java/com/atvantiq/wfms/ui/screens/dashboard/tabs/projectDashboard/ProjectDashboardVM.kt
@@ -1,0 +1,35 @@
+package com.atvantiq.wfms.ui.screens.dashboard.tabs.projectDashboard
+
+import android.app.Application
+import androidx.lifecycle.MutableLiveData
+import com.atvantiq.wfms.base.BaseViewModel
+import com.atvantiq.wfms.data.repository.budget.IBudgetRepo
+import com.atvantiq.wfms.models.targets.MyProjectsResponse
+import com.atvantiq.wfms.network.ApiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.Calendar
+import javax.inject.Inject
+
+@HiltViewModel
+class ProjectDashboardVM @Inject constructor(
+    application: Application,
+    private val budgetRepo: IBudgetRepo
+) : BaseViewModel(application) {
+
+    val myProjectsResponse = MutableLiveData<ApiState<MyProjectsResponse>>()
+
+    var selectedMonth: Int = Calendar.getInstance().get(Calendar.MONTH) + 1
+    var selectedYear: Int = Calendar.getInstance().get(Calendar.YEAR)
+
+    init {
+        fetchMyProjects()
+    }
+
+    fun fetchMyProjects() {
+        val monthParam = "%04d-%02d".format(selectedYear, selectedMonth)
+        executeApiCall(
+            apiCall = { budgetRepo.myProjects(monthParam) },
+            liveData = myProjectsResponse
+        )
+    }
+}

--- a/app/src/main/res/drawable/bg_filter_chip_selected.xml
+++ b/app/src/main/res/drawable/bg_filter_chip_selected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/card_radius_large" />
+    <solid android:color="?attr/wfmsColorPrimary" />
+</shape>

--- a/app/src/main/res/drawable/bg_filter_chip_unselected.xml
+++ b/app/src/main/res/drawable/bg_filter_chip_unselected.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/card_radius_large" />
+    <solid android:color="?attr/wfmsColorSurface" />
+</shape>

--- a/app/src/main/res/drawable/bg_month_filter_chip.xml
+++ b/app/src/main/res/drawable/bg_month_filter_chip.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <stroke
+        android:width="1.5dp"
+        android:color="?attr/wfmsColorPrimary" />
+    <solid android:color="?attr/wfmsColorSurface" />
+</shape>

--- a/app/src/main/res/drawable/bg_search_bar.xml
+++ b/app/src/main/res/drawable/bg_search_bar.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="@dimen/card_radius_large" />
+    <solid android:color="?attr/wfmsColorSurface" />
+</shape>

--- a/app/src/main/res/drawable/bg_status_behind.xml
+++ b/app/src/main/res/drawable/bg_status_behind.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="#FEE2E2" />
+</shape>

--- a/app/src/main/res/drawable/bg_status_on_track.xml
+++ b/app/src/main/res/drawable/bg_status_on_track.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="#DCFCE7" />
+</shape>

--- a/app/src/main/res/drawable/bg_status_under_target.xml
+++ b/app/src/main/res/drawable/bg_status_under_target.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <solid android:color="#FEF3C7" />
+</shape>

--- a/app/src/main/res/drawable/ic_refresh_24.xml
+++ b/app/src/main/res/drawable/ic_refresh_24.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"
+        android:strokeColor="?attr/wfmsColorPrimary"
+        android:strokeWidth="0" />
+    <path
+        android:fillColor="?attr/wfmsColorPrimary"
+        android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z" />
+</vector>

--- a/app/src/main/res/drawable/progress_revenue.xml
+++ b/app/src/main/res/drawable/progress_revenue.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="4dp" />
+            <solid android:color="#E5E7EB" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <corners android:radius="4dp" />
+                <solid android:color="#166534" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/item_project_budget.xml
+++ b/app/src/main/res/layout/item_project_budget.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="2dp"
+        android:layout_marginEnd="2dp"
+        android:layout_marginBottom="@dimen/margin_small"
+        app:cardBackgroundColor="?attr/wfmsColorSurface"
+        app:cardCornerRadius="@dimen/card_radius"
+        app:cardElevation="@dimen/elevation_small">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/padding">
+
+            <!-- Row 1: Project name + status badge -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tvProjectName"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textColor="?attr/wfmsColorOnSurface"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    tools:text="AT&amp;T 5G Rollout" />
+
+                <TextView
+                    android:id="@+id/tvStatus"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_small"
+                    android:paddingStart="@dimen/padding_medium"
+                    android:paddingTop="5dp"
+                    android:paddingEnd="@dimen/padding_medium"
+                    android:paddingBottom="5dp"
+                    android:textSize="@dimen/default_medium_small_text"
+                    android:textStyle="bold"
+                    tools:background="@drawable/bg_status_on_track"
+                    tools:text="On Track"
+                    tools:textColor="@color/status_present_text" />
+
+            </LinearLayout>
+
+            <!-- Row 2: Client · Circle -->
+            <TextView
+                android:id="@+id/tvClientLocation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:textColor="?attr/wfmsColorOnSurfaceVariant"
+                android:textSize="@dimen/default_medium_small_text"
+                tools:text="AT&amp;T Networks · Northeast" />
+
+            <!-- Row 3: Progress bar -->
+            <ProgressBar
+                android:id="@+id/progressProject"
+                style="@android:style/Widget.ProgressBar.Horizontal"
+                android:layout_width="match_parent"
+                android:layout_height="6dp"
+                android:layout_marginTop="@dimen/margin_small"
+                android:max="100"
+                android:progressDrawable="@drawable/progress_revenue"
+                tools:progress="60" />
+
+            <!-- Row 4: Sites · Revenue -->
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small_extra"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tvSitesRatio"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?attr/wfmsColorOnSurface"
+                    android:textSize="@dimen/default_medium_small_text"
+                    android:textStyle="bold"
+                    tools:text="3/5" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=" sites  ·  "
+                    android:textColor="?attr/wfmsColorOnSurfaceVariant"
+                    android:textSize="@dimen/default_medium_small_text" />
+
+                <TextView
+                    android:id="@+id/tvRevenue"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="?attr/wfmsColorOnSurface"
+                    android:textSize="@dimen/default_medium_small_text"
+                    android:textStyle="bold"
+                    tools:text="$220K of $250K" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</layout>


### PR DESCRIPTION
…filter

- Add My Targets tab: monthly revenue, sites, active days, hours, efficiency from budget/emp/my-targets
- Add Projects tab: project cards with status badge, progress, revenue from budget/emp/my-projects
- Add BudgetRepo + IBudgetRepo, MyTargetsResponse, MyProjectsResponse models
- Add ProjectDashboardVM, ProjectBudgetAdapter, item_project_budget layout
- Add Work Management search bar with 500ms debounce and status filter chips (All/Pending/Active/Completed)
- WorkFilter uses StatusCodes constants; status query param uses encoded=true to prevent URL encoding
- workAssignedAll extended with search + status params; duplicate siteAssigned endpoint removed
- DateUtils.formatMonthYear/formatYearMonthString added; hardcoded month arrays removed from fragments
- Refresh button added to My Targets and Projects tabs
- Status badge drawables, filter chip drawables, progress drawable added